### PR TITLE
table 밑 enter 버그 수정, 선택한 셀 css 추가

### DIFF
--- a/src/components/Editor/Editor.tsx
+++ b/src/components/Editor/Editor.tsx
@@ -1,4 +1,4 @@
-import { useEditor, EditorContent } from "@tiptap/react";
+import { useEditor, EditorContent, mergeAttributes } from "@tiptap/react";
 import { useEffect, useState } from "react";
 import { Selection } from "prosemirror-state";
 
@@ -74,14 +74,20 @@ const Editor = ({
           if (event.key === "Enter") {
             const { state, dispatch } = view;
             const { $head } = state.selection;
-            const isBlockquote = $head.node(-1).type.name === "blockquote";
 
+            if (!$head.node(-1)) {
+              dispatch(state.tr.insertText("\n"));
+              return true;
+            }
+
+            const isBlockquote = $head.node(-1).type.name === "blockquote";
             // block quote일 경우에는 enter 시 blockquote 를 유지하고, 아닐 경우에는 줄바꿈을 한다.
             if (isBlockquote) {
               return true;
             }
 
-            const tr = state.tr.setSelection(Selection.atEnd(state.doc));
+            const endPos = state.doc.content.size;
+            const tr = state.tr.setSelection(Selection.near(state.doc.resolve(endPos)));
             dispatch(tr.scrollIntoView().insertText("\n"));
           }
 

--- a/src/styles/tiptap.scss
+++ b/src/styles/tiptap.scss
@@ -147,6 +147,10 @@
         border-right: 1px solid #6d6d6f;
         border-bottom: 1px solid #6d6d6f;
       }
+
+      .selectedCell {
+        background-color: #353535;
+      }
     }
   }
 }


### PR DESCRIPTION
1. table 밑에 enter 선택시 node(-1)이 없어, 에러가 발생하여, enter가 적용되지 않음

2. 테이블 선택된 셀에 css를 입혀 가시적으로 보여줌