### PR TITLE
postForm 무한 렌더링 오류 해결

### DIFF
--- a/src/components/Editor/Editor.tsx
+++ b/src/components/Editor/Editor.tsx
@@ -1,4 +1,4 @@
-import { useEditor, EditorContent, mergeAttributes } from "@tiptap/react";
+import { useEditor, EditorContent } from "@tiptap/react";
 import { useEffect, useState } from "react";
 import { Selection } from "prosemirror-state";
 
@@ -12,6 +12,7 @@ import TableHeader from "@tiptap/extension-table-header";
 import TableRow from "@tiptap/extension-table-row";
 import ImageResize from "tiptap-extension-resize-image";
 import Placeholder from "@tiptap/extension-placeholder";
+import ListItem from "@tiptap/extension-list-item";
 
 import classes from "./Editor.module.scss";
 
@@ -20,7 +21,6 @@ import Toolbar from "./Toolbar/Toolbar";
 import { Indent } from "@/utils/indent";
 import CustomCodeBlockLowlight from "@/utils/codeBlockIndent";
 import { YoutubeResize } from "@/utils/youtubeResize";
-import ListItem from "@tiptap/extension-list-item";
 
 type EditorProps = {
   changeValue?: string;

--- a/src/components/PostForm/PostForm.tsx
+++ b/src/components/PostForm/PostForm.tsx
@@ -165,19 +165,12 @@ const PostForm = ({ postSuccess, onPost, boardId }: PostFormProps) => {
 
   const handleChange = useCallback(
     <K extends keyof Omit<RequestBoard, "imageIds" | "tagIds">>(key: K, value: RequestBoard[K]) => {
-      let filteredImageIds = undefined;
-
-      if (key === "content") {
-        filteredImageIds = request.imageIds?.filter((id) => checkAltValue(request.content, id));
-      }
-
       setRequest((prev) => ({
         ...prev,
         [key]: value,
-        imageIds: filteredImageIds ? [...filteredImageIds] : prev.imageIds,
       }));
     },
-    [request.content, request.imageIds],
+    [],
   );
 
   const handleTags = useCallback((tags: Tag[]) => {
@@ -187,16 +180,36 @@ const PostForm = ({ postSuccess, onPost, boardId }: PostFormProps) => {
     }));
   }, []);
 
-  const handleImage = useCallback(
-    (imageId: number) => {
-      const filteredImageIds = request.imageIds?.filter((id) => checkAltValue(request.content, id));
+  const getUserImage = useCallback(() => {
+    const filteredImageIds = request.imageIds?.filter((id) => checkAltValue(request.content, id));
+    return filteredImageIds;
+  }, [request.content, request.imageIds]);
 
-      setRequest((prev) => ({
-        ...prev,
-        imageIds: filteredImageIds ? [...filteredImageIds, imageId] : [...(prev.imageIds || []), imageId],
-      }));
+  const handleImage = useCallback(
+    (imageId?: number) => {
+      if (imageId) {
+        const filteredImageIds = getUserImage();
+
+        setRequest((prev) => ({
+          ...prev,
+          imageIds: filteredImageIds ? [...filteredImageIds, imageId] : [...(prev.imageIds || []), imageId],
+        }));
+      } else {
+        setRequest((prev) => ({
+          ...prev,
+          imageIds: getUserImage(),
+        }));
+      }
     },
-    [request.content, request.imageIds],
+    [getUserImage],
+  );
+
+  const handleContentChange = useCallback(
+    (content: string) => {
+      handleImage();
+      handleChange("content", content);
+    },
+    [handleChange],
   );
 
   useEffect(() => {
@@ -282,7 +295,7 @@ const PostForm = ({ postSuccess, onPost, boardId }: PostFormProps) => {
             isVisibleToolbar
             changeValue={changeContent}
             placeholder="내용을 입력해주세요."
-            onChange={(content: string) => handleChange("content", content)}
+            onChange={handleContentChange}
             onChangeImage={handleImage}
             className={classes.editor}
           />

--- a/src/features/TagSelect/TagSelect.tsx
+++ b/src/features/TagSelect/TagSelect.tsx
@@ -40,6 +40,7 @@ const TagSelect = ({ label = "태그 (1 ~ 3개)", initialTags, onSelect }: TagSe
         return;
       }
 
+      setSelectedTags([...value]);
       onSelect([...value]);
     },
     [onSelect],
@@ -48,6 +49,8 @@ const TagSelect = ({ label = "태그 (1 ~ 3개)", initialTags, onSelect }: TagSe
   const handleDelete = useCallback(
     (tag: Tag) => {
       const newTags = selectedTags.filter((item) => item.tagId !== tag.tagId);
+
+      setSelectedTags(newTags);
       onSelect(newTags);
     },
     [selectedTags, onSelect],
@@ -72,7 +75,7 @@ const TagSelect = ({ label = "태그 (1 ~ 3개)", initialTags, onSelect }: TagSe
       loading={isLoading}
       value={selectedTags}
       onChange={handleTagChange}
-      options={tags ? tags.tags : []}
+      options={tags?.tags || []}
       getOptionLabel={(option) => option.tagName}
       isOptionEqualToValue={(option: Tag, value: Tag) => option.tagId === value.tagId}
       // 가져온 검색 값을 다 보여주기 위함.


### PR DESCRIPTION
기존 코드에서는 handleChange 함수를 통해 content를 업데이트 하였음.

하지만, handleChange에서 request.content를 기반으로 이미지 실제 사용 여부를 추려냈고, useCallbasck 의존성 배열에는 request.content가 들어가게 됨.

content 변경 시 request.content를 바꾸고, 의존성 배열에 request.content가 있으니, 무한 재렌더링이 발생

handleChange 부르기 전, 이미지 실제 사용 여부를 체크하는 메소드를 새로 생성 및 호출하도록 변경